### PR TITLE
Issue #2923527: Undefined index: menu_name in menu_item_extras_preprocess_menu()

### DIFF
--- a/menu_item_extras.module
+++ b/menu_item_extras.module
@@ -253,7 +253,7 @@ function menu_item_extras_theme_suggestions_menu_alter(array &$suggestions, arra
  */
 function menu_item_extras_preprocess_menu(&$variables) {
   // We preprocess only menus that has additional fields.
-  if (Utility::checkBundleHasExtraFieldsThanEntity('menu_link_content', $variables['menu_name'])) {
+  if (!empty($variables['menu_name']) && Utility::checkBundleHasExtraFieldsThanEntity('menu_link_content', $variables['menu_name'])) {
     $variables['items'] = \Drupal::service('menu_item_extras.menu_link_tree_handler')
       ->processMenuLinkTree($variables['items']);
   }


### PR DESCRIPTION
> It's difficult to say what's causing the menu_name to not be set.
> 
> This issue had the same problem on a different function: https://www.drupal.org/node/2902013 and the reporter suspected it has something to do with admin_toolbar, which I do have installed.
> 
> This issue from the menu_block module seems to be dealing with the same problem, and seems to imply it's a caching issue when the menu tree is empty: https://www.drupal.org/node/2765411
> 
> I can try to look into it more, but it seems like we should include the check as the same check is getting performed a few lines above, in the menu_item_extras_theme_suggestions_menu_alter() function.
> 